### PR TITLE
Fix CPP check for GHC version 9.2

### DIFF
--- a/src/Data/Label.hs
+++ b/src/Data/Label.hs
@@ -124,7 +124,7 @@ find :: Label a -> a
 find (Label !(I32# n#)) = findWorker n#
 
 {-# NOINLINE findWorker #-}
-#if __GLASGOW_HASKELL__ >= 920
+#if __GLASGOW_HASKELL__ >= 902
 findWorker :: Int32# -> a
 #else
 findWorker :: Int# -> a


### PR DESCRIPTION
Check for 902 (that is nine point two), not for 920 (that is nine point twenty).