### PR TITLE
Cabal test

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: ./*.cabal src/twee-lib.cabal

--- a/misc/Test.hs
+++ b/misc/Test.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE TemplateHaskell, FlexibleInstances, FlexibleContexts, UndecidableInstances, StandaloneDeriving, ScopedTypeVariables, TupleSections, DeriveGeneric, DerivingVia, DeriveAnyClass #-}
-module Test where
+module Main where
 
 import Twee.Constraints
 import Twee.Term hiding (subst, canonicalise, F)

--- a/src/twee-lib.cabal
+++ b/src/twee-lib.cabal
@@ -62,14 +62,15 @@ library
     Twee.Term
     Twee.Task
     Twee.Utils
+    Twee.Term.Core
     Data.Label
+  other-modules:
     Data.BatchedQueue
     Data.ChurchList
     Data.DynamicArray
     Data.Heap
     Data.Numbered
     Data.PackedSequence
-    Twee.Term.Core
 
   build-depends:
     base >= 4 && < 5,

--- a/twee.cabal
+++ b/twee.cabal
@@ -69,3 +69,16 @@ executable twee
 
   if flag(static-cxx)
     ghc-options: -pgml misc/static-libstdc++
+
+Test-Suite twee-test
+    type: exitcode-stdio-1.0
+    Default-language: Haskell2010
+    hs-source-dirs:
+        misc
+    main-is: Test.hs
+    build-depends: base < 5, QuickCheck, twee-lib == 2.4.2, containers, pretty
+    ghc-options:
+      -threaded
+      -rtsopts
+      -feager-blackholing
+      -with-rtsopts=-N4


### PR DESCRIPTION
The properties in `misc/Test.hs` run by writing `cabal test`, as opposed to leading everything up manually ( scary! ).